### PR TITLE
Fix newFile() error

### DIFF
--- a/offline-editor/js/editor.js
+++ b/offline-editor/js/editor.js
@@ -46,8 +46,15 @@ function newFile() {
   hasWriteAccess = false;
   Entryflg = 0;
   handleDocumentChange(null);
-  //var xmlDoc = Blockly.Xml.textToDom('<xml xmlns="http://www.w3.org/1999/xhtml"><block type="initializes_setup" id="0" x="10" y="10"><next><block type="initializes_loop" id="1"></block></next></block></xml>');
-  //Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xmlDoc);
+  var xmlDoc = Blockly.Xml.textToDom('<xml xmlns="http://www.w3.org/1999/xhtml"><block type="initializes_setup" id="0" x="10" y="10"><next><block type="initializes_loop" id="1"></block></next></block></xml>');
+  var f = function(){
+    if(Blockly.mainWorkspace == null){
+  	  setTimeout(f, 200);
+  	} else { 
+  	  Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xmlDoc);
+  	}
+  };
+  f();
 }
 
 function setFile(theFileEntry, isWritable) {


### PR DESCRIPTION
Blockly.mainWorkSpace wasn't initialized when called by popup.js